### PR TITLE
Added a Quick Settings Tile to toggle DrawAnywhere service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DrawAnywhere">
+        <service
+            android:name=".DrawAnywhereTileService"
+            android:label="DrawAnywhere"
+            android:icon="@drawable/ic_tile_draw"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/shezik/drawanywhere/DrawAnywhereTileService.kt
+++ b/app/src/main/java/com/shezik/drawanywhere/DrawAnywhereTileService.kt
@@ -1,0 +1,43 @@
+package com.shezik.drawanywhere
+
+import android.content.Intent
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.provider.Settings
+
+class DrawAnywhereTileService: TileService(){
+
+    override fun onClick() {
+        super.onClick()
+        val serviceIntent = Intent(this, MainService::class.java)
+
+        if (isServiceRunning) {
+            stopService(serviceIntent)
+            qsTile.state = Tile.STATE_INACTIVE
+        } else {
+            if (!Settings.canDrawOverlays(this)) {
+                val permissionIntent = Intent(this, MainActivity::class.java)
+                permissionIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivityAndCollapse(permissionIntent)
+                return
+            } else {
+                startForegroundService(serviceIntent)
+                qsTile.state = Tile.STATE_ACTIVE
+            }
+        }
+
+        qsTile.updateTile()
+    }
+
+    private val isServiceRunning: Boolean
+        get() = MainService::class.java.name in (getSystemService(ACTIVITY_SERVICE) as android.app.ActivityManager)
+            .getRunningServices(Int.MAX_VALUE)
+            .map { it.service.className }
+
+    override fun onStartListening() {
+        super.onStartListening()
+        qsTile.state = if (isServiceRunning) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        qsTile.updateTile()
+    }
+
+}

--- a/app/src/main/res/drawable/ic_tile_draw.xml
+++ b/app/src/main/res/drawable/ic_tile_draw.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34a0.9959,0.9959 0,0,0 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>


### PR DESCRIPTION
Closes #3 

- Implemented TileService (DrawAnywhereTileService) to control MainService start/stop.
- Modified AndroidManifest to add permission for Quick Settings integration.
- Created a new XML drawable resource for the tile icon