### PR TITLE
Toolbar improvements, new customization options, and bug fixes

### DIFF
--- a/DrawToolbar.kt
+++ b/DrawToolbar.kt
@@ -1,0 +1,1179 @@
+/*
+DrawAnywhere: An Android application that lets you draw on top of other apps.
+Copyright (C) 2025 shezik
+
+This program is free software: you can redistribute it and/or modify it under the
+terms of the GNU Affero General Public License as published by the Free Software
+Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.shezik.drawanywhere
+
+import android.annotation.SuppressLint
+import androidx.compose.animation.*
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.Redo
+import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.shezik.drawanywhere.ui.theme.DrawAnywhereTheme
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import kotlin.math.roundToInt
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
+import com.shezik.drawanywhere.BuildConfig  // For AboutScreen version string
+
+// TODO: Modifiers (esp. size) unification
+
+data class ToolbarButton(
+    val id: String,
+    val icon: ImageVector,
+    val color: Color? = null,
+    val contentDescription: String,
+    val isEnabled: Boolean = true,
+    val onClick: (() -> Unit)? = null,
+    val popupPages: List<@Composable () -> Unit> = emptyList(),
+    val onPopupDismiss: (() -> Unit)? = null  // NEW: For auto-closing after actions like color pick
+) {
+    val hasPopup: Boolean
+        get() = popupPages.isNotEmpty()
+}
+
+enum class ToolbarOrientation {
+    HORIZONTAL, VERTICAL
+}
+
+fun Modifier.scaledLayout(scale: Float): Modifier = this.then(
+    object : LayoutModifier {
+        override fun MeasureScope.measure(
+            measurable: Measurable,
+            constraints: Constraints
+        ): MeasureResult {
+            val placeable = measurable.measure(constraints)
+            val width = (placeable.width * scale).roundToInt()
+            val height = (placeable.height * scale).roundToInt()
+            return layout(width, height) {
+                placeable.placeWithLayer(0, 0) {
+                    scaleX = scale
+                    scaleY = scale
+                    transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0f, 0f)
+                }
+            }
+        }
+    }
+)
+
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@Composable
+fun DrawToolbar(
+    viewModel: DrawViewModel,
+    modifier: Modifier = Modifier
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val canUndo by viewModel.canUndo.collectAsState()
+    val canRedo by viewModel.canRedo.collectAsState()
+    val canClearCanvas by viewModel.canClearCanvas.collectAsState()
+    val serviceState by viewModel.serviceState.collectAsState()  // NEW: For active/dim logic
+
+    val haptics = LocalHapticFeedback.current
+    val hScrollState = rememberScrollState()
+    val vScrollState = rememberScrollState()
+
+    val allButtonsMap = createAllToolbarButtons(
+        uiState = uiState,
+        canUndo = canUndo,
+        canRedo = canRedo,
+        canClearCanvas = canClearCanvas,
+        onCanvasVisibilityToggle = viewModel::toggleCanvasVisibility,
+        onCanvasPassthroughToggle = viewModel::toggleCanvasPassthrough,
+        onClearCanvas = viewModel::clearCanvas,
+        onUndo = viewModel::undo,
+        onRedo = viewModel::redo,
+        onPenTypeSwitch = viewModel::switchToPen,
+        onColorChange = viewModel::setPenColor,
+        onStrokeWidthChange = viewModel::setStrokeWidth,
+        onAlphaChange = viewModel::setStrokeAlpha,
+        onChangeOrientation = viewModel::setToolbarOrientation,
+        onChangeAutoClearCanvas = viewModel::setAutoClearCanvas,
+        onChangeVisibleOnStart = viewModel::setVisibleOnStart,
+        onToolbarScaleChange = viewModel::setToolbarScale,  // NEW
+        onToolbarInactiveAlphaChange = viewModel::setToolbarInactiveAlpha,  // NEW
+        onQuitApplication = viewModel::quitApplication,
+        onSetToolbarActive = viewModel::setToolbarActive,
+        onResetToolbarTimer = viewModel::resetToolbarTimer
+
+    ).associateBy { it.id }
+
+    DrawAnywhereTheme {
+        // Root composable
+        BoxWithConstraints {
+            DraggableToolbarCard(
+                modifier = modifier
+                    .scaledLayout(uiState.toolbarScale)
+                    .wrapContentSize(unbounded = false)
+                    .widthIn(max = maxWidth)
+                    .heightIn(max = maxHeight)
+                    .scrollFadingEdges(hScrollState, false)
+                    .scrollFadingEdges(vScrollState, true)
+                    .horizontalScroll(hScrollState)
+                    .verticalScroll(vScrollState)
+                    .padding(4.dp),
+                uiState = uiState,
+                serviceState = serviceState,
+                haptics = haptics,
+                onPositionChange = viewModel::updateToolbarPosition,
+                onPositionSaved = viewModel::saveToolbarPosition,
+                onToolbarInteracted = viewModel::resetToolbarTimer
+            ) {
+                ToolbarButtonsContainer(
+                    modifier = Modifier.padding(8.dp),
+                    uiState = uiState,
+                    allButtonsMap = allButtonsMap,
+                    onExpandToggleClick = viewModel::toggleSecondDrawer
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DraggableToolbarCard(
+    modifier: Modifier = Modifier,
+    uiState: UiState,
+    serviceState: ServiceState,  // From earlier param add
+    haptics: HapticFeedback,
+    onPositionChange: (Offset) -> Unit,
+    onPositionSaved: () -> Unit,
+    onToolbarInteracted: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    val animatedAlpha by animateFloatAsState( //NEW Animation
+        targetValue = if (serviceState.toolbarActive) 1f else uiState.toolbarInactiveAlpha,
+        animationSpec = tween(durationMillis = 300),  // Matches the original duration
+        label = "toolbar_alpha"
+    )
+
+    Card(
+        modifier = modifier
+            
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        awaitPointerEvent()
+                        onToolbarInteracted()
+                    }
+                }
+            }
+            .pointerInput(Unit) {
+                detectDragGesturesAfterLongPress(
+                    onDragStart = {
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        onPositionChange(dragAmount)
+                    },
+                    onDragEnd = {
+                        onPositionSaved()
+                    }
+                )
+            }
+            .graphicsLayer { alpha = animatedAlpha
+            },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = CircleShape,
+        colors = CardDefaults.cardColors(  // FIXED: Back to fixed alpha—no dynamic here anymore
+            containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = .88f) //BG alpha
+        )
+    ) {
+
+        content()  // Calls ToolbarButtonsContainer safely here
+    }
+}
+@Composable
+private fun ToolbarButtonsContainer(
+    modifier: Modifier = Modifier,
+    uiState: UiState,
+    allButtonsMap: Map<String, ToolbarButton>,
+    onExpandToggleClick: () -> Unit
+) {
+    val orientation = uiState.toolbarOrientation
+    val isFirstDrawerOpen = uiState.firstDrawerOpen
+    val isSecondDrawerOpen = uiState.secondDrawerOpen
+    val firstDrawerButtonIds = uiState.firstDrawerButtons
+    val secondDrawerButtonIds = uiState.secondDrawerButtons
+    val secondDrawerPinnedButtons = uiState.secondDrawerPinnedButtons
+
+    val standaloneButtonIds = allButtonsMap.keys.filter {
+        it !in firstDrawerButtonIds &&
+                it !in secondDrawerButtonIds
+    }
+
+    val arrangement = Arrangement.spacedBy(8.dp)
+    val popupAlignment = when (orientation) {
+        ToolbarOrientation.HORIZONTAL -> Alignment.TopCenter
+        ToolbarOrientation.VERTICAL -> Alignment.CenterEnd
+    }
+
+    // Animate the size of the container holding the expandable buttons
+    val animatedContentSize = Modifier.animateContentSize(
+        animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+    )
+
+    when (orientation) {
+        // REMEMBER TO SYNC VERTICAL CODE WITH HORIZONTAL CODE
+        // HORIZONTAL CODE IS THE MOST ACCURATE
+        ToolbarOrientation.HORIZONTAL -> {
+            Row(
+                modifier = modifier.then(animatedContentSize),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = arrangement
+            ) {
+                standaloneButtonIds.forEach { buttonId ->
+                    val button = allButtonsMap[buttonId] ?: return@forEach
+                    RenderButton(button, popupAlignment)
+                }
+
+                firstDrawerButtonIds.forEach { buttonId ->
+                    val button = allButtonsMap[buttonId] ?: return@forEach
+                    AnimatedVisibility(
+                        visible = isFirstDrawerOpen,
+                        enter = fadeIn(tween(300)) + scaleIn(tween(300), initialScale = 0.5f),
+                        exit = fadeOut(tween(300)) + scaleOut(tween(300), targetScale = 0.5f)
+                    ) {
+                        RenderButton(button, popupAlignment)
+                    }
+                }
+
+                val isDividerVisible = isFirstDrawerOpen && (
+                        secondDrawerPinnedButtons.isNotEmpty()
+                                || (isSecondDrawerOpen && secondDrawerButtonIds.isNotEmpty())
+                        )
+                AnimatedVisibility(
+                    visible = isDividerVisible,
+                    enter = fadeIn(tween(300)),
+                    exit = fadeOut(tween(300))
+                ) {
+                    VerticalDivider(
+                        modifier = Modifier
+                            .height(24.dp)
+                            .padding(horizontal = 8.dp),
+                        thickness = 2.dp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    )
+                }
+
+                secondDrawerButtonIds.forEach { buttonId ->
+                    val button = allButtonsMap[buttonId] ?: return@forEach
+                    val isVisible =
+                        isFirstDrawerOpen && (isSecondDrawerOpen || buttonId in secondDrawerPinnedButtons)
+
+                    AnimatedVisibility(
+                        visible = isVisible,
+                        enter = fadeIn(tween(300)) + scaleIn(tween(300), initialScale = 0.5f),
+                        exit = fadeOut(tween(300)) + scaleOut(tween(300), targetScale = 0.5f)
+                    ) {
+                        RenderButton(button, popupAlignment)
+                    }
+                }
+
+                val isExpandButtonVisible =
+                    isFirstDrawerOpen && secondDrawerButtonIds.isNotEmpty()
+                AnimatedVisibility(
+                    visible = isExpandButtonVisible,
+                    enter = fadeIn(tween(300)) + scaleIn(tween(300), initialScale = 0.5f),
+                    exit = fadeOut(tween(300)) + scaleOut(tween(300), targetScale = 0.5f)
+                ) {
+                    ToolbarExpandButton(
+                        modifier = Modifier,
+                        isExpanded = isSecondDrawerOpen,
+                        onClick = onExpandToggleClick,
+                        orientation = orientation
+                    )
+                }
+            }
+        }
+
+        ToolbarOrientation.VERTICAL -> {
+            Column(
+                modifier = modifier.then(animatedContentSize),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = arrangement
+            ) {
+                standaloneButtonIds.forEach { buttonId ->
+                    val button = allButtonsMap[buttonId] ?: return@forEach
+                    RenderButton(button, popupAlignment)
+                }
+
+                firstDrawerButtonIds.forEach { buttonId ->
+                    val button = allButtonsMap[buttonId] ?: return@forEach
+                    AnimatedVisibility(
+                        visible = isFirstDrawerOpen,
+                        enter = fadeIn(tween(300)) + scaleIn(tween(300), initialScale = 0.5f),
+                        exit = fadeOut(tween(300)) + scaleOut(tween(300), targetScale = 0.5f)
+                    ) {
+                        RenderButton(button, popupAlignment)
+                    }
+                }
+
+                val isDividerVisible = isFirstDrawerOpen && (
+                        secondDrawerPinnedButtons.isNotEmpty()
+                                || (isSecondDrawerOpen && secondDrawerButtonIds.isNotEmpty())
+                        )
+                AnimatedVisibility(
+                    visible = isDividerVisible,
+                    enter = fadeIn(tween(300)),
+                    exit = fadeOut(tween(300))
+                ) {
+                    HorizontalDivider(
+                        modifier = Modifier
+                            .width(24.dp)
+                            .padding(vertical = 8.dp),
+                        thickness = 2.dp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    )
+                }
+
+                secondDrawerButtonIds.forEach { buttonId ->
+                    val button = allButtonsMap[buttonId] ?: return@forEach
+                    val isVisible =
+                        isFirstDrawerOpen && (isSecondDrawerOpen || buttonId in secondDrawerPinnedButtons)
+
+                    AnimatedVisibility(
+                        visible = isVisible,
+                        enter = fadeIn(tween(300)) + scaleIn(tween(300), initialScale = 0.5f),
+                        exit = fadeOut(tween(300)) + scaleOut(tween(300), targetScale = 0.5f)
+                    ) {
+                        RenderButton(button, popupAlignment)
+                    }
+                }
+
+                val isExpandButtonVisible =
+                    isFirstDrawerOpen && secondDrawerButtonIds.isNotEmpty()
+                AnimatedVisibility(
+                    visible = isExpandButtonVisible,
+                    enter = fadeIn(tween(300)) + scaleIn(tween(300), initialScale = 0.5f),
+                    exit = fadeOut(tween(300)) + scaleOut(tween(300), targetScale = 0.5f)
+                ) {
+                    ToolbarExpandButton(
+                        modifier = Modifier,
+                        isExpanded = isSecondDrawerOpen,
+                        onClick = onExpandToggleClick,
+                        orientation = orientation
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RenderButton(button: ToolbarButton, popupAlignment: Alignment, modifier: Modifier = Modifier) {
+    if (button.hasPopup) {
+        PopupToolbarButton(
+            modifier = modifier,
+            button = button,
+            popupAlignment = popupAlignment
+        )
+    } else {
+        AnimatedToolbarButton(
+            modifier = modifier,
+            button = button
+        )
+    }
+}
+
+@Composable
+private fun ToolbarExpandButton(
+    modifier: Modifier,
+    isExpanded: Boolean,
+    onClick: () -> Unit,
+    orientation: ToolbarOrientation
+) {
+    val targetAngles =
+        when (orientation) {
+            ToolbarOrientation.HORIZONTAL -> 180f to 0f
+            ToolbarOrientation.VERTICAL -> 270f to 90f
+        }
+
+    val rotationAngle by animateFloatAsState(
+        targetValue = if (isExpanded) targetAngles.first else targetAngles.second,
+        animationSpec = tween(300, easing = FastOutSlowInEasing),
+        label = "toggle_rotation"
+    )
+
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+//            .size(40.dp)
+            .background(
+                color = if (isExpanded)
+                    MaterialTheme.colorScheme.primaryContainer
+                else
+                    MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+                shape = CircleShape  // Apply CircleShape here for background
+            )
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = if (isExpanded) stringResource(R.string.collapse_toolbar) else stringResource(R.string.expand_toolbar),
+            tint = if (isExpanded)
+                MaterialTheme.colorScheme.onPrimaryContainer
+            else
+                MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.graphicsLayer { rotationZ = rotationAngle }
+        )
+    }
+}
+
+@Composable
+private fun AnimatedToolbarButton(modifier: Modifier, button: ToolbarButton) {
+    val iconColor = button.color ?: MaterialTheme.colorScheme.onSurface
+
+    val scale by animateFloatAsState(
+        targetValue = if (button.isEnabled) 1f else 0.9f,
+        animationSpec = tween(200),
+        label = "button_scale"
+    )
+
+    IconButton(
+        onClick = button.onClick ?: { },
+        enabled = button.isEnabled,
+        modifier = Modifier.background(
+            color = if (button.isEnabled)
+                MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)  // BOOSTED: Matches above for uniform crisp
+            else
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+            shape = CircleShape
+        )
+    ) {
+        Icon(
+            imageVector = button.icon,
+            contentDescription = button.contentDescription,
+            tint = if (button.isEnabled)
+                button.color ?: MaterialTheme.colorScheme.onSurface
+            else
+                (button.color ?: MaterialTheme.colorScheme.onSurface).copy(alpha = 0.4f)
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun PopupToolbarButton(
+    modifier: Modifier,
+    button: ToolbarButton,
+    popupAlignment: Alignment
+) {
+    var isPopupOpen by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(
+            onClick = {
+                if (isPopupOpen) {
+                    button.onPopupDismiss?.invoke()
+                }
+                isPopupOpen = !isPopupOpen
+            },
+            enabled = button.isEnabled,
+            modifier = Modifier.background(
+                color = if (isPopupOpen)
+                    MaterialTheme.colorScheme.primaryContainer
+                else if (button.isEnabled)
+                    MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)  // BOOSTED: Crisp circles, no merge/sheer
+                else
+                    MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
+                shape = CircleShape
+            )
+        ) {
+            Icon(
+                imageVector = button.icon,
+                contentDescription = button.contentDescription,
+                tint = if (isPopupOpen)
+                    button.color ?: MaterialTheme.colorScheme.onPrimaryContainer
+                else if (button.isEnabled)
+                    button.color ?: MaterialTheme.colorScheme.onSurface
+                else
+                    (button.color ?: MaterialTheme.colorScheme.onSurface).copy(alpha = 0.4f)
+            )
+        }
+        if (isPopupOpen && button.popupPages.isNotEmpty()) {
+            val pagerState = rememberPagerState(initialPage = 0) { button.popupPages.size }
+
+            Popup(
+                alignment = popupAlignment,
+                offset = when (popupAlignment) {
+                    Alignment.TopCenter -> IntOffset(0, -60)
+                    Alignment.CenterEnd -> IntOffset(60, 0)
+                    else -> IntOffset(0, 0)
+                },
+                onDismissRequest = { isPopupOpen = false },
+                properties = PopupProperties(focusable = false)  // <-- This is the key line
+            ) {
+                // ... (the Card and rest stays the same)
+
+                Card(
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .width(200.dp),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier
+                                .animateContentSize(),
+                            verticalAlignment = Alignment.Top
+                        ) { page ->
+                            button.popupPages[page].invoke()
+                        }
+
+                        if (button.popupPages.size > 1) {
+                            Row(
+                                Modifier
+                                    .fillMaxWidth(),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                repeat(button.popupPages.size) { index ->
+                                    val selected = pagerState.currentPage == index
+                                    Box(
+                                        modifier = Modifier
+                                            .size(if (selected) 10.dp else 6.dp)
+                                            .padding(2.dp)
+                                            .background(
+                                                color = if (selected) MaterialTheme.colorScheme.onSurface
+                                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                                                shape = CircleShape
+                                            )
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+@Composable
+private fun PenTypeSelector(
+    currentPenType: PenType,
+    onPenTypeSwitch: (PenType) -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+//        modifier = Modifier.width(120.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.tools),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        val penTypes = listOf(
+            PenType.Pen to stringResource(R.string.pen),
+            PenType.StrokeEraser to stringResource(R.string.stroke_eraser)
+        )
+
+        penTypes.forEach { (penType, label) ->
+            val isSelected = currentPenType == penType
+            val backgroundColor = if (isSelected)
+                MaterialTheme.colorScheme.primaryContainer
+            else
+                MaterialTheme.colorScheme.surface
+            val contentColor = if (isSelected)
+                MaterialTheme.colorScheme.onPrimaryContainer
+            else
+                MaterialTheme.colorScheme.onSurface
+
+            Button(
+                onClick = { onPenTypeSwitch(penType) },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = backgroundColor,
+                    contentColor = contentColor
+                ),
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorSwatchButton(
+    color: Color,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val scale by animateFloatAsState(
+        targetValue = if (isSelected) 1.2f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "color_button_scale"
+    )
+
+    Box(
+        modifier = Modifier
+            .size(24.dp)
+            .graphicsLayer { scaleX = scale; scaleY = scale }
+            .clip(CircleShape) // Ensure clipping is applied to the box
+            .background(color)
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = if (isSelected)
+                    MaterialTheme.colorScheme.primary
+                else
+                    MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                shape = CircleShape
+            )
+            .clickable { onClick() }
+    )
+}
+
+@Composable
+private fun ColorPicker(
+    selectedColor: Color,
+    onColorSelected: (Color) -> Unit,
+    onDismiss: (() -> Unit)? = null  // NEW: Callback to close popup after select
+) {
+    val colors = listOf(
+        Color.Red, Color.Blue, Color.Green, Color.Yellow,
+        Color.Magenta, Color.Cyan, Color.Black, Color.Gray,
+        Color.White, Color(0xFF8BC34A), Color(0xFFFF9800), Color(0xFF9C27B0)
+    )
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.color),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            colors.chunked(4).forEach { colorRow ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceAround
+                ) {
+                    colorRow.forEach { color ->
+                        ColorSwatchButton(
+                            color = color,
+                            isSelected = color.toArgb() == selectedColor.toArgb(),
+                            onClick = {
+                                onColorSelected(color)
+                                onDismiss?.invoke()  // NEW: Auto-dismiss after picking
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(2.dp))
+        }
+    }
+}
+
+@Composable
+private fun PenControls(
+    penConfig: PenConfig,
+    onStrokeWidthChange: (Float) -> Unit,
+    onAlphaChange: (Float) -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.tool_controls),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        SliderControl(
+            label = stringResource(R.string.width),
+            value = penConfig.width,
+            valueRange = 1f..50f,
+            onValueChange = onStrokeWidthChange,
+            valueDisplay = { "${it.toInt()}px" }
+        )
+
+        SliderControl(
+            label = stringResource(R.string.opacity),
+            value = penConfig.alpha,
+            valueRange = 0.1f..1f,
+            onValueChange = onAlphaChange,
+            valueDisplay = { "${(it * 100).toInt()}%" }
+        )
+    }
+}
+
+@Composable
+private fun ToolbarControls(
+    currentOrientation: ToolbarOrientation,
+    onChangeOrientation: (ToolbarOrientation) -> Unit,
+    autoClearCanvas: Boolean,
+    onChangeAutoClearCanvas: (Boolean) -> Unit,
+    visibleOnStart: Boolean,
+    onChangeVisibleOnStart: (Boolean) -> Unit,
+    toolbarScale: Float,  // NEW
+    onToolbarScaleChange: (Float) -> Unit,  // NEW
+    toolbarInactiveAlpha: Float,  // NEW
+    onToolbarInactiveAlphaChange: (Float) -> Unit,  // NEW
+    onQuitApplication: () -> Unit,
+    onSetToolbarActive: (Boolean) -> Unit
+) {
+
+    // NEW: Local state and scope for drag preview
+    val coroutineScope = rememberCoroutineScope()
+    var isPreviewingOpacity by remember { mutableStateOf(false) }
+    var brightenJob: Job? by remember { mutableStateOf(null) }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+//        modifier = Modifier.width(120.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.settings),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        val orientations = listOf(
+            ToolbarOrientation.HORIZONTAL to stringResource(R.string.horizontal),
+            ToolbarOrientation.VERTICAL to stringResource(R.string.vertical)
+        )
+
+        orientations.forEach { (orientation, label) ->
+            val isSelected = currentOrientation == orientation
+            val backgroundColor = if (isSelected)
+                MaterialTheme.colorScheme.primaryContainer
+            else
+                MaterialTheme.colorScheme.surface
+            val contentColor = if (isSelected)
+                MaterialTheme.colorScheme.onPrimaryContainer
+            else
+                MaterialTheme.colorScheme.onSurface
+
+            Button(
+                onClick = { onChangeOrientation(orientation) },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = backgroundColor,
+                    contentColor = contentColor
+                ),
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+
+        CheckboxControl(
+            label = stringResource(R.string.clear_on_hiding_canvas),
+            isChecked = autoClearCanvas,
+            onCheckedChange = onChangeAutoClearCanvas
+        )
+
+        CheckboxControl(
+            label = stringResource(R.string.canvas_visible_on_start),
+            isChecked = visibleOnStart,
+            onCheckedChange = onChangeVisibleOnStart
+        )
+        // NEW: Toolbar size slider
+        SliderControl(
+            label = stringResource(R.string.toolbar_size),
+            value = toolbarScale,
+            valueRange = 0.2f..1.0f,  // CHANGED: 20% min, 100% max—no oversized vibes
+            onValueChange = onToolbarScaleChange,
+            valueDisplay = { "${(it * 100).toInt()}%" }
+        )
+
+        // NEW: Toolbar inactive opacity slider
+        SliderControl(
+            label = stringResource(R.string.toolbar_inactive_opacity),
+            value = toolbarInactiveAlpha,
+            valueRange = 0.1f..1.0f,
+            onValueChange = { newAlpha ->
+                // Trigger preview: Dim immediately and update alpha
+                if (!isPreviewingOpacity) {
+                    onSetToolbarActive(false)
+                }
+                isPreviewingOpacity = true
+                onToolbarInactiveAlphaChange(newAlpha)  // Updates uiState, so animatedAlpha reacts live
+
+                // Restart delay to brighten after drag ends
+                brightenJob?.cancel()
+                brightenJob = coroutineScope.launch {
+                    delay(1000L)  // Adjust if too short/long (e.g., 300L for snappier)
+                    isPreviewingOpacity = false
+                    onSetToolbarActive(true)  // Brighten back
+                    brightenJob = null
+                }
+            },
+            valueDisplay = { "${(it * 100).toInt()}%" }
+        )
+        Button(
+            onClick = onQuitApplication,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            ),
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.quit),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@Composable
+fun AboutScreen() {
+    Box(modifier = Modifier.padding(12.dp)) {  // Looks nice.
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.app_icon),
+                contentDescription = stringResource(R.string.app_name),
+                modifier = Modifier.size(72.dp),
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
+            )
+
+            Text(
+                text = stringResource(R.string.app_name),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Text(
+                text = "${BuildConfig.VERSION_NAME}${if (BuildConfig.DEBUG) "-dev" else ""} (${BuildConfig.VERSION_CODE})",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.ExtraLight,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(R.string.copyright),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Light,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.licenses),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Light,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun SliderControl(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    onValueChange: (Float) -> Unit,
+    valueDisplay: (Float) -> String
+) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = valueDisplay(value),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Slider(
+            modifier = Modifier.height(30.dp),
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            colors = SliderDefaults.colors(
+                thumbColor = MaterialTheme.colorScheme.primary,
+                activeTrackColor = MaterialTheme.colorScheme.primary,
+                inactiveTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+            )
+        )
+    }
+}
+
+@Composable
+private fun CheckboxControl(
+    label: String,
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    description: String? = null
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceAround,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            description?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.ExtraLight,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+
+        Checkbox(
+            checked = isChecked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier
+                .width(24.dp)
+                .height(24.dp),
+            colors = CheckboxDefaults.colors(
+                checkmarkColor = MaterialTheme.colorScheme.onPrimary,
+                checkedColor = MaterialTheme.colorScheme.primary,
+                uncheckedColor = MaterialTheme.colorScheme.outline
+            )
+        )
+    }
+}
+
+@Composable
+private fun createAllToolbarButtons(
+    uiState: UiState,
+    canUndo: Boolean,
+    canRedo: Boolean,
+    canClearCanvas: Boolean,
+    onCanvasVisibilityToggle: () -> Unit,
+    onCanvasPassthroughToggle: () -> Unit,
+    onClearCanvas: () -> Unit,
+    onUndo: () -> Unit,
+    onRedo: () -> Unit,
+    onPenTypeSwitch: (PenType) -> Unit,
+    onColorChange: (Color) -> Unit,
+    onStrokeWidthChange: (Float) -> Unit,
+    onAlphaChange: (Float) -> Unit,
+    onChangeOrientation: (ToolbarOrientation) -> Unit,
+    onChangeAutoClearCanvas: (Boolean) -> Unit,
+    onChangeVisibleOnStart: (Boolean) -> Unit,
+    onToolbarScaleChange: (Float) -> Unit,  // NEW
+    onToolbarInactiveAlphaChange: (Float) -> Unit,  // NEW: Calls the new setter
+    onSetToolbarActive: (Boolean) -> Unit,  // NEW: For preview dim/brighten
+    onResetToolbarTimer: () -> Unit,  // NEW: To restart idle timer on dismiss
+    onQuitApplication: () -> Unit
+): List<ToolbarButton> {
+    return listOf(
+        ToolbarButton(
+            id = "visibility",
+            icon = if (uiState.canvasVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+            contentDescription = if (uiState.canvasVisible) stringResource(R.string.hide_canvas) else stringResource(R.string.show_canvas),
+            onClick = onCanvasVisibilityToggle
+        ),
+
+        ToolbarButton(
+            id = "undo",
+            icon = Icons.AutoMirrored.Filled.Undo,
+            contentDescription = stringResource(R.string.undo),
+            isEnabled = uiState.canvasVisible && canUndo,
+            onClick = onUndo
+        ),
+
+        ToolbarButton(
+            id = "clear",
+            icon = if (canClearCanvas) Icons.Filled.Delete else Icons.Outlined.Delete,
+            contentDescription = stringResource(R.string.clear_canvas),
+            isEnabled = uiState.canvasVisible && canClearCanvas,
+            onClick = onClearCanvas
+        ),
+
+        ToolbarButton(
+            id = "tool_controls",
+            icon = when (uiState.currentPenType) {
+                PenType.Pen -> Icons.Default.Edit
+                PenType.StrokeEraser -> InkEraser24Px
+            },
+            contentDescription = stringResource(R.string.tool_controls),
+            popupPages = listOf(
+                { PenTypeSelector(
+                    currentPenType = uiState.currentPenType,
+                    onPenTypeSwitch = onPenTypeSwitch
+                ) },
+
+                { PenControls(
+                    penConfig = uiState.currentPenConfig,
+                    onStrokeWidthChange = onStrokeWidthChange,
+                    onAlphaChange = onAlphaChange
+                ) }
+            )
+        ),
+
+        ToolbarButton(
+            id = "color_picker",
+            icon = Icons.Default.Palette,
+            color = uiState.currentPenConfig.color,
+            contentDescription = stringResource(R.string.color_picker),
+            popupPages = listOf(
+                { ColorPicker(
+                    selectedColor = uiState.currentPenConfig.color,
+                    onColorSelected = onColorChange
+                ) }
+            )
+        ),
+
+        ToolbarButton(
+            id = "passthrough",
+            icon = if (uiState.canvasPassthrough) Icons.Default.DoNotTouch else Icons.Default.TouchApp,
+            contentDescription = if (uiState.canvasPassthrough) stringResource(R.string.disable_passthrough) else stringResource(R.string.enable_passthrough),
+            isEnabled = uiState.canvasVisible,
+            onClick = onCanvasPassthroughToggle
+        ),
+
+        ToolbarButton(
+            id = "redo",
+            icon = Icons.AutoMirrored.Filled.Redo,
+            contentDescription = stringResource(R.string.redo),
+            isEnabled = uiState.canvasVisible && canRedo,
+            onClick = onRedo
+        ),
+
+        ToolbarButton(
+            id = "settings",
+            icon = Icons.Default.Tune,
+            contentDescription = stringResource(R.string.settings),
+            popupPages = listOf(
+                {
+
+                    ToolbarControls(
+                    currentOrientation = uiState.toolbarOrientation,
+                    onChangeOrientation = onChangeOrientation,
+                    autoClearCanvas = uiState.autoClearCanvas,
+                    onChangeAutoClearCanvas = onChangeAutoClearCanvas,
+                    visibleOnStart = uiState.visibleOnStart,
+                    onChangeVisibleOnStart = onChangeVisibleOnStart,
+                    toolbarScale = uiState.toolbarScale,  // NEW
+                    onToolbarScaleChange = onToolbarScaleChange,  // NEW
+                    toolbarInactiveAlpha = uiState.toolbarInactiveAlpha,  // NEW
+                    onToolbarInactiveAlphaChange = onToolbarInactiveAlphaChange,  // NEW
+                    onQuitApplication = onQuitApplication,
+                        onSetToolbarActive = onSetToolbarActive
+                ) },
+                { AboutScreen() }
+            ),
+            onPopupDismiss = {
+                onResetToolbarTimer()
+            }
+        )
+    )
+}

--- a/DrawViewModel.kt
+++ b/DrawViewModel.kt
@@ -1,0 +1,350 @@
+/*
+DrawAnywhere: An Android application that lets you draw on top of other apps.
+Copyright (C) 2025 shezik
+
+This program is free software: you can redistribute it and/or modify it under the
+terms of the GNU Affero General Public License as published by the Free Software
+Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.shezik.drawanywhere
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ServiceState(
+    // Saved
+    val toolbarPosition: Offset = Offset(32f, 64f),
+    val toolbarActive: Boolean = true,
+
+    // Not saved
+    val positionValidated: Boolean = false,
+)
+
+data class UiState(
+    val canvasVisible: Boolean = true,  // Overridden on start by visibleOnStart in PreferencesManager
+    val canvasPassthrough: Boolean = false,
+    val autoClearCanvas: Boolean = false,
+    val visibleOnStart: Boolean = true,
+
+    val currentPenType: PenType = PenType.Pen,  // This could be morphed into pen IDs later, if multiple pens with the same type is desired.
+    val penConfigs: Map<PenType, PenConfig> = defaultPenConfigs(),
+
+    val toolbarOrientation: ToolbarOrientation = ToolbarOrientation.HORIZONTAL,
+    val firstDrawerOpen: Boolean = canvasVisible,
+    val secondDrawerOpen: Boolean = false,
+
+    // Second drawer expand/collapse button is UI-specific, we don't (and shouldn't) see it here
+    // Buttons that don't appear in either drawer are "standalone"s, e.g. the visibility button
+    val firstDrawerButtons: Set<String> = setOf(
+        "undo", "clear", "tool_controls", "color_picker"
+    ),
+    val secondDrawerButtons: Set<String> = setOf(
+        "passthrough", "redo", "settings"
+    ),
+    // Buttons that stay in second drawer but do not collapse
+    val secondDrawerPinnedButtons: Set<String> = emptySet(),
+    val toolbarScale: Float = 0.8f,  // NEW: Scale factor for toolbar size (0.5-1.2)
+    val toolbarInactiveAlpha: Float = .5f  // NEW: Alpha when inactive (0.2-1.0)
+) {
+    val currentPenConfig: PenConfig
+        // New PenConfig is not added until modified
+        get() = penConfigs[currentPenType] ?: PenConfig()  // Triggering fallback would be weird. Creating a new tool?
+}
+
+fun defaultPenConfigs(): Map<PenType, PenConfig> = mapOf(
+    PenType.Pen to PenConfig(penType = PenType.Pen),
+    PenType.StrokeEraser to PenConfig(penType = PenType.StrokeEraser, width = 50f)
+)
+
+
+
+@OptIn(FlowPreview::class)
+class DrawViewModel(
+    private val controller: DrawController,
+    private val preferencesMgr: PreferencesManager,
+    initialUiState: UiState,
+    initialServiceState: ServiceState,
+    private val stopService: () -> Unit
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(initialUiState)
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    private val _serviceState = MutableStateFlow(initialServiceState)
+    val serviceState: StateFlow<ServiceState> = _serviceState.asStateFlow()
+
+    val canUndo: StateFlow<Boolean> = controller.canUndo
+    val canRedo: StateFlow<Boolean> = controller.canRedo
+    val canClearCanvas: StateFlow<Boolean> = controller.canClearPaths
+
+    init {
+        controller.setPenConfig(initialUiState.currentPenConfig)
+
+        _uiState
+            .onEach { state ->
+                preferencesMgr.saveUiState(state)
+            }
+            .launchIn(viewModelScope)
+
+        _uiState
+            .onEach { state ->
+                // TODO: Should we move pinned buttons logic here?
+                controller.setPenConfig(state.currentPenConfig)
+            }
+            .launchIn(viewModelScope)
+
+        _serviceState
+            .onEach { state ->
+                preferencesMgr.saveServiceState(state)  // ADDED: Auto-save on any service state change (e.g., active toggle)
+            }
+            .launchIn(viewModelScope)
+        resetToolbarTimer()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        dimmingJob?.cancel()
+    }
+
+    fun switchToPen(type: PenType) =
+        _uiState.update { it.copy(currentPenType = type) }
+
+    // TODO: Save to preferences, configurable
+    fun resolvePenType(modifier: StrokeModifier) =
+        when (modifier) {
+            StrokeModifier.PrimaryButton   -> PenType.StrokeEraser
+            StrokeModifier.SecondaryButton -> PenType.StrokeEraser  // TODO
+            StrokeModifier.Both            -> PenType.StrokeEraser  // You might be experiencing a stroke
+            StrokeModifier.None            -> uiState.value.currentPenType
+        }
+
+
+
+    var previousPenType: PenType? = null
+    var isStrokeDown = false
+
+    fun startStroke(point: Offset, modifier: StrokeModifier) {
+        finishStroke()  // Oh no! No multitouch! Who cares.
+
+        val newPenType = resolvePenType(modifier)
+        if (newPenType != uiState.value.currentPenType) {
+            previousPenType = uiState.value.currentPenType
+            switchToPen(newPenType)
+        }
+
+        controller.createPath(point)
+        isStrokeDown = true
+    }
+
+    fun updateStroke(point: Offset) {
+        if (!isStrokeDown) return
+        controller.updateLatestPath(point)
+    }
+
+    fun finishStroke() {
+        if (!isStrokeDown) return
+
+        controller.finishPath()
+
+        previousPenType?.let {
+            switchToPen(it)
+            previousPenType = null
+        }
+        isStrokeDown = false
+    }
+
+
+
+    fun toggleCanvasVisibility() =
+        setCanvasVisibility(!uiState.value.canvasVisible)
+
+    fun setCanvasVisibility(visible: Boolean) {
+        var currentCanvasPassthrough = uiState.value.canvasPassthrough
+        var currentPinned = uiState.value.secondDrawerPinnedButtons
+
+        if (uiState.value.autoClearCanvas && !visible) {
+            clearCanvas()
+            currentCanvasPassthrough = false
+            currentPinned = getPinSecondDrawerButtonResult("passthrough", false)
+        }
+
+        val currentFirstDrawerOpen = uiState.value.firstDrawerOpen
+        _uiState.update { it.copy(
+            canvasVisible = visible,
+            canvasPassthrough = currentCanvasPassthrough,
+            firstDrawerOpen = !currentFirstDrawerOpen,
+            secondDrawerPinnedButtons = currentPinned
+        ) }
+    }
+
+
+
+    fun toggleCanvasPassthrough() =
+        setCanvasPassthrough(!uiState.value.canvasPassthrough)
+
+    fun setCanvasPassthrough(passthrough: Boolean) {
+        val newPinned = getPinSecondDrawerButtonResult("passthrough", passthrough)
+        _uiState.update { it.copy(canvasPassthrough = passthrough, secondDrawerPinnedButtons = newPinned) }
+    }
+
+
+
+    fun setPenColor(color: Color) =
+        _uiState.update {
+            with (it) {
+                val newConfigs = penConfigs.toMutableMap()
+                val newPenConfig = newConfigs[currentPenType]?.copy(color = color)
+                    ?: PenConfig(color = color, penType = currentPenType)
+                newConfigs[currentPenType] = newPenConfig
+                copy(penConfigs = newConfigs)
+            }
+        }
+
+    fun setStrokeWidth(width: Float) =
+        _uiState.update {
+            with (it) {
+                val newConfigs = penConfigs.toMutableMap()
+                val newPenConfig = newConfigs[currentPenType]?.copy(width = width)
+                    ?: PenConfig(width = width, penType = currentPenType)
+                newConfigs[currentPenType] = newPenConfig
+                copy(penConfigs = newConfigs)
+            }
+        }
+
+    fun setStrokeAlpha(alpha: Float) =
+        _uiState.update {
+            with (it) {
+                val newConfigs = penConfigs.toMutableMap()
+                val newPenConfig = newConfigs[currentPenType]?.copy(alpha = alpha)
+                    ?: PenConfig(alpha = alpha, penType = currentPenType)
+                newConfigs[currentPenType] = newPenConfig
+                copy(penConfigs = newConfigs)
+            }
+        }
+    fun setToolbarScale(scale: Float) =
+        _uiState.update { it.copy(toolbarScale = scale) }
+
+    fun setToolbarInactiveAlpha(alpha: Float) =
+        _uiState.update {
+            it.copy(toolbarInactiveAlpha = alpha)
+        }
+
+
+    fun setToolbarPosition(position: Offset, validated: Boolean = false) =
+        _serviceState.update { it.copy(toolbarPosition = position, positionValidated = validated) }
+
+    fun updateToolbarPosition(offset: Offset) =
+        setToolbarPosition(serviceState.value.toolbarPosition + offset)
+
+    fun saveToolbarPosition() = viewModelScope.launch {
+        // THERE'S A LOTTA CONCURRENCY GOING ON HERE, BEWARE!
+        // We should be fine (FOR NOW) since the only value saved is toolbar position
+        preferencesMgr.saveServiceState(serviceState.value)
+    }
+
+
+
+    fun clearCanvas() = controller.clearPaths()
+    fun undo() = controller.undo()
+    fun redo() = controller.redo()
+
+
+
+    private var dimmingJob: Job? = null
+
+    fun resetToolbarTimer() {
+        dimmingJob?.cancel()
+        setToolbarActive(true)
+        dimmingJob = viewModelScope.launch {
+            delay(3000L)
+            setToolbarActive(false)
+        }
+    }
+
+    fun setToolbarActive(state: Boolean) =
+        _serviceState.update {
+            it.copy(toolbarActive = state)
+        }
+
+
+    fun toggleToolbarOrientation() =
+        setToolbarOrientation(
+            when (uiState.value.toolbarOrientation) {
+                ToolbarOrientation.VERTICAL -> ToolbarOrientation.HORIZONTAL
+                ToolbarOrientation.HORIZONTAL -> ToolbarOrientation.VERTICAL
+            }
+        )
+
+    fun setToolbarOrientation(orientation: ToolbarOrientation) =
+        _uiState.update { it.copy(toolbarOrientation = orientation) }
+
+
+
+    fun toggleFirstDrawer() =
+        setFirstDrawerOpen(!uiState.value.firstDrawerOpen)
+
+    fun setFirstDrawerOpen(state: Boolean) =
+        _uiState.update { it.copy(firstDrawerOpen = state) }
+
+    fun toggleSecondDrawer() =
+        setSecondDrawerOpen(!uiState.value.secondDrawerOpen)
+
+    fun setSecondDrawerOpen(state: Boolean) =
+        _uiState.update { it.copy(secondDrawerOpen = state) }
+
+
+
+    fun toggleSecondDrawerPinned(id: String) {
+        val currentPinned = uiState.value.secondDrawerPinnedButtons
+        pinSecondDrawerButton(id, !currentPinned.contains(id))
+    }
+
+    fun pinSecondDrawerButton(id: String, pinned: Boolean) =
+        _uiState.update { it.copy(secondDrawerPinnedButtons = getPinSecondDrawerButtonResult(id, pinned)) }
+
+    private fun getPinSecondDrawerButtonResult(id: String, pinned: Boolean): Set<String> {
+        val currentPinned = uiState.value.secondDrawerPinnedButtons
+        if (currentPinned.contains(id) == pinned)
+            return currentPinned
+
+        return if (pinned)
+            currentPinned + id
+        else
+            currentPinned - id
+    }
+
+
+
+    fun setAutoClearCanvas(state: Boolean) =
+        _uiState.update { it.copy(autoClearCanvas = state) }
+
+    fun setVisibleOnStart(state: Boolean) =
+        _uiState.update { it.copy(visibleOnStart = state) }
+
+    fun quitApplication() {
+        viewModelScope.launch {
+            preferencesMgr.saveUiState(uiState.value)
+            preferencesMgr.saveServiceState(serviceState.value)
+            stopService()
+        }
+    }
+}

--- a/MainService.kt
+++ b/MainService.kt
@@ -1,0 +1,238 @@
+/*
+DrawAnywhere: An Android application that lets you draw on top of other apps.
+Copyright (C) 2025 shezik
+
+This program is free software: you can redistribute it and/or modify it under the
+terms of the GNU Affero General Public License as published by the Free Software
+Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.shezik.drawanywhere
+
+import android.app.Service
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.graphics.PixelFormat
+import android.graphics.Point
+import android.os.Build
+import android.os.IBinder
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.graphics.Color
+import androidx.core.app.NotificationCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import android.view.WindowManager.LayoutParams
+import android.view.WindowInsets
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.round
+import androidx.core.app.ServiceCompat
+
+class MainService : Service() {
+    companion object {
+        private const val NOTIFICATION_ID = 100
+        private const val CHANNEL_ID = "default_channel"
+    }
+
+    private val customLifecycleOwner = CustomLifecycleOwner()
+    private lateinit var windowManager: WindowManager
+    private lateinit var canvasView: View
+    private lateinit var toolbarView: View
+    private val drawController = DrawController()
+    private lateinit var preferencesMgr: PreferencesManager
+    private lateinit var viewModel: DrawViewModel
+    private var uiStateJob: Job? = null
+    private var serviceStateJob: Job? = null
+
+    override fun onCreate() {
+        super.onCreate()
+
+        preferencesMgr = PreferencesManager(this)
+        val (initialUiState, initialServiceState) = runBlocking {
+            preferencesMgr.getSavedUiState() to preferencesMgr.getSavedServiceState()
+        }
+        viewModel = DrawViewModel(
+            controller = drawController,
+            preferencesMgr = preferencesMgr,
+            initialUiState = initialUiState,
+            initialServiceState = initialServiceState,
+            stopService = { stopSelf() }
+        )
+
+        customLifecycleOwner.onCreate()
+        customLifecycleOwner.onResume()
+        windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+
+        createNotificationChannel()
+        ServiceCompat.startForeground(this, NOTIFICATION_ID, createNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+
+        // -------- Setup canvas --------
+        canvasView = ComposeView(this).apply {
+            setContent {
+                DrawCanvas(
+                    modifier = Modifier.fillMaxSize()
+                        .stylusAwareDrawing(viewModel = viewModel),
+                    controller = drawController,
+                    backgroundColor = Color.Transparent
+                )
+            }
+        }
+        customLifecycleOwner.attachToDecorView(canvasView)
+
+        val canvasParams = LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.TYPE_APPLICATION_OVERLAY,
+            LayoutParams.FLAG_NOT_FOCUSABLE or
+                    LayoutParams.FLAG_NOT_TOUCH_MODAL or
+//                    LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                    LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+            PixelFormat.TRANSLUCENT
+        )
+
+        handleCanvasPassthrough(canvasParams, initialUiState)
+        // ------------------------------
+
+        // -------- Setup toolbar --------
+        toolbarView = ComposeView(this).apply {
+            setContent {
+                DrawToolbar(viewModel = viewModel)
+            }
+        }
+        customLifecycleOwner.attachToDecorView(toolbarView)
+
+        val toolbarParams = LayoutParams(
+            LayoutParams.WRAP_CONTENT,
+            LayoutParams.WRAP_CONTENT,
+            LayoutParams.TYPE_APPLICATION_OVERLAY,
+            LayoutParams.FLAG_NOT_FOCUSABLE or
+                    LayoutParams.FLAG_NOT_TOUCH_MODAL or
+//                    LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                    LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+            PixelFormat.TRANSLUCENT
+        )
+        toolbarParams.gravity = Gravity.TOP or
+                Gravity.START
+
+        handleToolbarPosition(toolbarParams, initialServiceState, windowManager, toolbarView, viewModel)
+        // -------------------------------
+
+        windowManager.addView(canvasView, canvasParams)
+        windowManager.addView(toolbarView, toolbarParams)
+
+        uiStateJob = CoroutineScope(Dispatchers.Main).launch {
+            viewModel.uiState.collect { state ->
+                handleCanvasPassthrough(canvasParams, state)
+                windowManager.updateViewLayout(canvasView, canvasParams)
+
+                canvasView.visibility = if (state.canvasVisible)
+                    View.VISIBLE else View.GONE
+            }
+        }
+
+        serviceStateJob = CoroutineScope(Dispatchers.Main).launch {
+            viewModel.serviceState.collect { state ->
+                handleToolbarPosition(toolbarParams, state, windowManager, toolbarView, viewModel)
+                windowManager.updateViewLayout(toolbarView, toolbarParams)
+
+            }
+        }
+    }
+
+    private fun handleCanvasPassthrough(
+        canvasParams: LayoutParams,
+        state: UiState
+    ) {
+        canvasParams.flags = if (state.canvasPassthrough)
+            canvasParams.flags or LayoutParams.FLAG_NOT_TOUCHABLE
+        else
+            canvasParams.flags and LayoutParams.FLAG_NOT_TOUCHABLE.inv()
+    }
+
+    private fun handleToolbarPosition(
+        toolbarParams: LayoutParams,
+        state: ServiceState,
+        windowManager: WindowManager,
+        toolbarView: View,
+        viewModel: DrawViewModel
+    ) {
+        val rounded = state.toolbarPosition.round()
+
+        if (state.positionValidated) {
+            toolbarParams.x = rounded.x
+            toolbarParams.y = rounded.y
+        } else {
+            val (screenWidth, screenHeight) = getUsableScreenSize(windowManager)
+            val coercedX = rounded.x.coerceIn(0, screenWidth - toolbarView.width)
+            val coercedY = rounded.y.coerceIn(0, screenHeight - toolbarView.height)
+            viewModel.setToolbarPosition(Offset(coercedX.toFloat(), coercedY.toFloat()), true)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getUsableScreenSize(windowManager: WindowManager): Pair<Int, Int> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val windowMetrics = windowManager.maximumWindowMetrics
+            val insets = windowMetrics.windowInsets.getInsets(
+                WindowInsets.Type.navigationBars()
+            )
+            val bounds = windowMetrics.bounds
+            val usableWidth = bounds.width() - insets.left - insets.right
+            val usableHeight = bounds.height() - insets.top - insets.bottom
+            usableWidth to usableHeight
+        } else {
+            val display = windowManager.defaultDisplay
+            val size = Point()
+            display.getSize(size)
+            size.x to size.y
+        }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        uiStateJob?.cancel()
+        serviceStateJob?.cancel()
+        if (::toolbarView.isInitialized && toolbarView.isAttachedToWindow)
+            windowManager.removeView(toolbarView)
+        if (::canvasView.isInitialized && canvasView.isAttachedToWindow)
+            windowManager.removeView(canvasView)
+        customLifecycleOwner.onPause()
+        customLifecycleOwner.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.app_name),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun createNotification(): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.app_name))
+            .setSmallIcon(android.R.drawable.ic_menu_edit)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .build()
+    }
+}

--- a/PreferencesManager.kt
+++ b/PreferencesManager.kt
@@ -1,0 +1,159 @@
+/*
+DrawAnywhere: An Android application that lets you draw on top of other apps.
+Copyright (C) 2025 shezik
+
+This program is free software: you can redistribute it and/or modify it under the
+terms of the GNU Affero General Public License as published by the Free Software
+Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.shezik.drawanywhere
+
+import android.content.Context
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+class PreferencesManager(private val context: Context) {
+    private object PreferencesKeys {
+        val CURRENT_PEN_TYPE = stringPreferencesKey("current_pen_type")
+        val TOOLBAR_POSITION_X = floatPreferencesKey("toolbar_position_x")
+        val TOOLBAR_POSITION_Y = floatPreferencesKey("toolbar_position_y")
+        val TOOLBAR_ORIENTATION = stringPreferencesKey("toolbar_orientation")
+        val AUTO_CLEAR_CANVAS = booleanPreferencesKey("auto_clear_canvas")
+        val VISIBLE_ON_START = booleanPreferencesKey("visible_on_start")
+
+        // Pen-specific keys (for saving multiple pens)
+        fun penColorKey(penType: PenType) = intPreferencesKey("${penType.name}_color")
+        fun penWidthKey(penType: PenType) = floatPreferencesKey("${penType.name}_width")
+        fun penAlphaKey(penType: PenType) = floatPreferencesKey("${penType.name}_alpha")
+        // NEW: Keys for additional UiState fields
+        val TOOLBAR_SCALE = floatPreferencesKey("toolbar_scale")
+        val TOOLBAR_INACTIVE_ALPHA = floatPreferencesKey("toolbar_inactive_alpha")
+
+        // NEW: Key for ServiceState (saved fields)
+        val TOOLBAR_ACTIVE = booleanPreferencesKey("toolbar_active")
+    }
+
+    inline fun <reified T : Enum<T>> getEnumValueOrDefault(
+        value: String?,
+        defaultValue: T
+    ): T {
+        if (value == null) return defaultValue
+        return try {
+            enumValueOf(value)
+        } catch (_: IllegalArgumentException) {
+            defaultValue
+        }
+    }
+
+    suspend fun getSavedUiState(): UiState {
+        val preferences = context.dataStore.data.first()
+        val defaultUiState = UiState()
+
+        val currentPenType = getEnumValueOrDefault<PenType>(
+            preferences[PreferencesKeys.CURRENT_PEN_TYPE],
+            defaultUiState.currentPenType)
+
+        // Reconstruct pen configurations
+        val penConfigs = defaultUiState.penConfigs.toMutableMap()
+        for (penType in PenType.entries) {
+            val color = preferences[PreferencesKeys.penColorKey(penType)]
+            val width = preferences[PreferencesKeys.penWidthKey(penType)]
+            val alpha = preferences[PreferencesKeys.penAlphaKey(penType)]
+
+            if (color != null || width != null || alpha != null) {
+                penConfigs[penType] = PenConfig(
+                    penType = penType,
+                    // Should never reach Color.Red, unless defaultPenConfigs is not elaborate
+                    color = color?.let { Color(it) } ?: penConfigs[penType]?.color ?: Color.Red,
+                    // We don't have common default values for the two below
+                    width = width ?: penConfigs[penType]?.width ?: 10f,
+                    alpha = alpha ?: penConfigs[penType]?.alpha ?: 1f
+                )
+            }
+        }
+
+        val visibleOnStart = preferences[PreferencesKeys.VISIBLE_ON_START] ?: defaultUiState.visibleOnStart
+
+        // NEW: Load additional UiState fields
+        val toolbarScale = preferences[PreferencesKeys.TOOLBAR_SCALE] ?: defaultUiState.toolbarScale
+        val toolbarInactiveAlpha = preferences[PreferencesKeys.TOOLBAR_INACTIVE_ALPHA] ?: defaultUiState.toolbarInactiveAlpha
+
+        return UiState(
+            currentPenType = currentPenType,
+            penConfigs = penConfigs,
+            toolbarOrientation = getEnumValueOrDefault<ToolbarOrientation>(
+                preferences[PreferencesKeys.TOOLBAR_ORIENTATION],
+                defaultUiState.toolbarOrientation),
+            autoClearCanvas = preferences[PreferencesKeys.AUTO_CLEAR_CANVAS] ?: defaultUiState.autoClearCanvas,
+
+            visibleOnStart = visibleOnStart,
+            canvasVisible = visibleOnStart,
+            firstDrawerOpen = visibleOnStart,
+            toolbarScale = toolbarScale, //NEW: Include the loaded values
+            toolbarInactiveAlpha = toolbarInactiveAlpha
+        )
+    }
+
+    suspend fun saveUiState(uiState: UiState) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.CURRENT_PEN_TYPE] = uiState.currentPenType.name
+            preferences[PreferencesKeys.TOOLBAR_ORIENTATION] = uiState.toolbarOrientation.name
+            preferences[PreferencesKeys.AUTO_CLEAR_CANVAS] = uiState.autoClearCanvas
+            preferences[PreferencesKeys.VISIBLE_ON_START] = uiState.visibleOnStart
+
+            // Save each pen's configuration
+            for ((penType, config) in uiState.penConfigs) {
+                preferences[PreferencesKeys.penColorKey(penType)] = config.color.toArgb()
+                preferences[PreferencesKeys.penWidthKey(penType)] = config.width
+                preferences[PreferencesKeys.penAlphaKey(penType)] = config.alpha
+                // NEW: Save additional UiState fields
+                preferences[PreferencesKeys.TOOLBAR_SCALE] = uiState.toolbarScale
+                preferences[PreferencesKeys.TOOLBAR_INACTIVE_ALPHA] = uiState.toolbarInactiveAlpha
+            }
+        }
+    }
+
+    suspend fun getSavedServiceState(): ServiceState {
+        val preferences = context.dataStore.data.first()
+        val defaultServiceState = ServiceState()
+        // NEW: Load saved toolbarActive
+        val toolbarActive = preferences[PreferencesKeys.TOOLBAR_ACTIVE] ?: defaultServiceState.toolbarActive
+
+        return ServiceState(
+            toolbarPosition = Offset(
+                x = preferences[PreferencesKeys.TOOLBAR_POSITION_X] ?: defaultServiceState.toolbarPosition.x,
+                y = preferences[PreferencesKeys.TOOLBAR_POSITION_Y] ?: defaultServiceState.toolbarPosition.y
+            ),
+            toolbarActive = toolbarActive
+        )
+    }
+
+    suspend fun saveServiceState(serviceState: ServiceState) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.TOOLBAR_POSITION_X] = serviceState.toolbarPosition.x
+            preferences[PreferencesKeys.TOOLBAR_POSITION_Y] = serviceState.toolbarPosition.y
+            // NEW: Save toolbarActive
+            preferences[PreferencesKeys.TOOLBAR_ACTIVE] = serviceState.toolbarActive
+        }
+    }
+}


### PR DESCRIPTION
– Fixed a bug where selecting a color required clicking the screen before drawing. It felt like a double clicking, now you can choose a color and start painting immediately.
– Added two sliders in the settings panel to customize toolbar size and inactive opacity, letting you adjust the size from 100% to 20% and opacity from 100% to 10%.
– Fixed margin issues that prevented the toolbar from being placed at the edges of the screen.

Everything is working well except for one issue I couldn’t solve: when moving the toolbar or adjusting its size, it flickers in a strange way. I tried different approaches but couldn’t remove the flicker. Other than that, everything else works as expected.